### PR TITLE
Include Dice Used in metadata

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -429,6 +429,7 @@ class FudgeDice extends UnaryDice {
       opType: roll.opType,
       metadata: RollMetadata(
         rolled: roll.results,
+        diceUsed: {'dF': ndice}
       ),
       left: lhs,
     );
@@ -475,6 +476,7 @@ class PercentDice extends UnaryDice {
       opType: OpType.rollPercent,
       metadata: RollMetadata(
         rolled: roll.results,
+        diceUsed: {'d$nsides': ndice}
       ),
       left: lhs,
     );
@@ -500,6 +502,7 @@ class D66Dice extends UnaryDice {
       results: results,
       metadata: RollMetadata(
         rolled: results,
+        diceUsed: {'d66': ndice}
       ),
       left: lhs,
     );
@@ -542,6 +545,7 @@ class StdDice extends BinaryDice {
       opType: roll.opType,
       metadata: RollMetadata(
         rolled: roll.results,
+        diceUsed: {'d$nsides': ndice}
       ),
       left: lhs,
       right: rhs,
@@ -636,6 +640,7 @@ class RerollDice extends BinaryDice {
       metadata: RollMetadata(
         rolled: added,
         discarded: discarded,
+        diceUsed: lhs.metadata.diceUsed
       ),
       left: lhs,
       right: rhs,
@@ -725,6 +730,7 @@ class CompoundingDice extends BinaryDice {
       metadata: RollMetadata(
         rolled: added,
         discarded: discarded,
+        diceUsed: lhs.metadata.diceUsed
       ),
       left: lhs,
       right: rhs,

--- a/lib/src/dice_roller.dart
+++ b/lib/src/dice_roller.dart
@@ -38,7 +38,10 @@ class DiceRoller with LoggingMixin {
     return RollResult(
       expression: '${ndice}d$nsides',
       opType: OpType.rollDice,
-      metadata: RollMetadata(rolled: results),
+      metadata: RollMetadata(
+        rolled: results,
+        diceUsed: {'d$nsides': ndice}
+      ),
       ndice: ndice,
       nsides: nsides,
       results: results,
@@ -62,7 +65,10 @@ class DiceRoller with LoggingMixin {
     return RollResult(
       expression: '${ndice}dF',
       opType: OpType.rollFudge,
-      metadata: RollMetadata(rolled: results),
+      metadata: RollMetadata(
+        rolled: results,
+        diceUsed: {'dF': ndice}
+      ),
       ndice: ndice,
       results: results,
     );
@@ -78,7 +84,10 @@ class DiceRoller with LoggingMixin {
     return RollResult(
       expression: '${ndice}d$sideVals',
       opType: OpType.rollVals,
-      metadata: RollMetadata(rolled: results),
+      metadata: RollMetadata(
+        rolled: results,
+        diceUsed: {'dF': ndice}
+      ),
       ndice: ndice,
       results: results,
     );

--- a/lib/src/results.dart
+++ b/lib/src/results.dart
@@ -125,11 +125,12 @@ class RollMetadata extends Equatable {
     this.rolled = const [],
     this.discarded = const [],
     this.score = const RollScore(),
-  });
+    this.diceUsed = const {}});
 
   final List<int> rolled;
   final List<int> discarded;
   final RollScore score;
+  final Map<String, int> diceUsed;
 
   bool get isEmpty => rolled.isEmpty && discarded.isEmpty && score.isEmpty;
 
@@ -137,10 +138,11 @@ class RollMetadata extends Equatable {
 
   @override
   List<Object?> get props => [
-        rolled,
-        discarded,
-        score,
-      ];
+    rolled,
+    discarded,
+    score,
+    diceUsed
+  ];
 
   @override
   String toString() => '${toJson()}';
@@ -149,15 +151,27 @@ class RollMetadata extends Equatable {
         'rolled': rolled,
         'discarded': discarded,
         'score': score.toJson(),
+        'diceUsed': diceUsed
       }..removeWhere(
           (k, v) => (v is List && v.isEmpty) || (v is Map && v.isEmpty),
         );
 
-  RollMetadata operator +(RollMetadata other) => RollMetadata(
+  RollMetadata operator +(RollMetadata other) {
+    final combinedDice = <String, int>{};
+    combinedDice.addAll(diceUsed);
+    other.diceUsed.forEach((key, value) {
+      if (combinedDice.containsKey(key)) {
+        combinedDice[key] = combinedDice[key]! + value;
+      } else {
+        combinedDice[key] = value;
+      }
+    });
+    return RollMetadata(
         rolled: rolled + other.rolled,
         discarded: discarded + other.discarded,
         score: score + other.score,
-      );
+        diceUsed: combinedDice);
+  }
 }
 
 /// [RollSummary] is the final result of rolling a dice expression.


### PR DESCRIPTION
Hello,

The goal of this PR is to keep track of which dice have been used in the formula, inside the metadata.

**Still pending:** The dice added by exploding dice are not added up in the count, but I would love to do so. Help welcome!

**To review:** I am not sure `diceUsed` is the best key name for this, other options: `dice`, `diceCounts`, `diceNum` `diceRolled`

Best regards
Saif